### PR TITLE
fix: fix typo CyberConnetStore => CyberConnectStore

### DIFF
--- a/src/cyberConnect.ts
+++ b/src/cyberConnect.ts
@@ -11,7 +11,7 @@ import { IDX } from '@ceramicstudio/idx';
 import { endpoints } from './network';
 import { follow, unfollow, setAlias } from './queries';
 import { ConnectError, ErrorCode } from './error';
-import { Endpoint, Blockchain, CyberConnetStore, Config } from './types';
+import { Endpoint, Blockchain, CyberConnectStore, Config } from './types';
 import { getAddressByProvider } from './utils';
 import { Caip10Link } from '@ceramicnetwork/stream-caip10-link';
 import { Env } from '.';
@@ -251,7 +251,7 @@ class CyberConnect {
     try {
       const result = (await this.idxInstance.get(
         'cyberConnect'
-      )) as CyberConnetStore;
+      )) as CyberConnectStore;
 
       return result?.outboundLink || [];
     } catch (e) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -20,7 +20,7 @@ export type SolananChainRef =
   | typeof solana.SOLANA_MAINNET_CHAIN_REF
   | typeof solana.SOLANA_TESTNET_CHAIN_REF;
 
-export interface CyberConnetStore {
+export interface CyberConnectStore {
   outboundLink: Connections;
 }
 


### PR DESCRIPTION
fix typo: `CyberConnetStore` => `CyberConnectStore`